### PR TITLE
Use underscore rather than hyphen in shortcode name

### DIFF
--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -24,4 +24,4 @@ function _eventorganiser_booking_confirmation_shortcode_handler($atts){
   return $html;
 }
 
-add_shortcode( 'booking-confirmation' , '_eventorganiser_booking_confirmation_shortcode_handler' );
+add_shortcode( 'booking_confirmation' , '_eventorganiser_booking_confirmation_shortcode_handler' );


### PR DESCRIPTION
Hi Andrew,

I've just tested this out and it works really well. 

One minor thing that caught my attention is that the shortcode uses a hyphen in the name. These are valid characters but they come with this health warning: https://codex.wordpress.org/Shortcode_API#Hyphens

It's up to you, but I'd recommend using a hyphen.
